### PR TITLE
Origin/feature/UI layout settingmenu

### DIFF
--- a/src/SettingsWindow.java
+++ b/src/SettingsWindow.java
@@ -1,0 +1,156 @@
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonType;
+
+public class SettingsWindow extends Stage {
+
+    private ToggleButton colorBlindModeToggle;
+    private MenuButton resizeMenuButton;
+    private Stage mainWindow;
+    private boolean isColorBlindModeOn;
+    private Button[] buttons;
+
+    public SettingsWindow(Stage mainWindow) {
+        this.mainWindow = mainWindow;
+        setTitle("설정");
+        setWidth(300);
+        setHeight(400);
+
+        BorderPane root = new BorderPane();
+
+        VBox buttonBox = new VBox();
+        buttonBox.setAlignment(Pos.CENTER);
+        buttonBox.setSpacing(10);
+        buttonBox.setPadding(new Insets(20));
+
+        FlowPane modePanel = new FlowPane();
+        modePanel.setAlignment(Pos.CENTER);
+        modePanel.setHgap(10);
+        Label colorBlindModeLabel = new Label("색맹 모드");
+        colorBlindModeToggle = new ToggleButton("off");
+        colorBlindModeToggle.setPrefSize(50, 25);
+        colorBlindModeToggle.setOnAction(event -> handleButtonClick(event));
+        colorBlindModeToggle.setFocusTraversable(false);
+        isColorBlindModeOn = false;
+        modePanel.getChildren().addAll(colorBlindModeLabel, colorBlindModeToggle);
+
+        FlowPane resizePanel = new FlowPane();
+        resizePanel.setAlignment(Pos.CENTER);
+        resizePanel.setHgap(10);
+        Label resizeLabel = new Label("화면 크기 조절");
+        resizeMenuButton = new MenuButton();
+        MenuItem item1 = new MenuItem("1");
+        item1.setOnAction(event -> {
+            resizeMenuButton.setText("1");
+        });
+        MenuItem item2 = new MenuItem("2");
+        item2.setOnAction(event -> {
+            resizeMenuButton.setText("2");
+        });
+        MenuItem item3 = new MenuItem("3");
+        item3.setOnAction(event -> {
+            resizeMenuButton.setText("3");
+        });
+        resizeMenuButton.getItems().addAll(item1, item2, item3);
+        resizeMenuButton.setText("1"); // 기본값 "1"로 설정
+
+        resizePanel.getChildren().addAll(resizeLabel, resizeMenuButton);
+
+        buttonBox.getChildren().addAll(modePanel, resizePanel);
+
+        Button keySettingsButton = new Button("키 설정");
+        Button resetScoreButton = new Button("기록 초기화");
+        Button resetAllButton = new Button("기본 설정으로 되돌리기");
+        Button backButton = new Button("뒤로가기");
+
+        buttons = new Button[]{keySettingsButton, resetScoreButton, resetAllButton, backButton};
+
+        for (Button button : buttons) {
+            button.setOnAction(event -> handleButtonClick(event));
+            button.setFocusTraversable(false);
+            button.setStyle("-fx-focus-color: transparent; -fx-faint-focus-color: transparent;"); // 포커스 제거
+            buttonBox.getChildren().add(button);
+        }
+
+        root.setCenter(buttonBox);
+
+        Scene scene = new Scene(root);
+        setScene(scene);
+    }
+
+    private void handleButtonClick(ActionEvent event) {
+        Object source = event.getSource();
+        if (source == colorBlindModeToggle) {
+            isColorBlindModeOn = !isColorBlindModeOn;
+            colorBlindModeToggle.setText(isColorBlindModeOn ? "on" : "off");
+        } else if (source instanceof Button) {
+            Button clickedButton = (Button) source;
+            String buttonText = clickedButton.getText();
+            if (buttonText.equals("뒤로가기")) {
+                hide();
+                mainWindow.show();
+            } else if (buttonText.equals("기본 설정으로 되돌리기")) {
+                showResetConfirmation();
+            } else if (buttonText.equals("기록 초기화")) {
+                showScoreResetConfirmation();
+            }
+        }
+    }
+
+    private void showResetConfirmation() {
+        Alert alert = new Alert(AlertType.CONFIRMATION);
+        alert.setTitle("설정 초기화");
+        alert.setHeaderText(null);
+        alert.setContentText("정말 기본 설정으로 되돌리시겠습니까?");
+
+        alert.showAndWait().ifPresent(result -> {
+            if (result == ButtonType.OK) {
+                resetSettings();
+            }
+        });
+    }
+
+    private void showScoreResetConfirmation() {
+        Alert alert = new Alert(AlertType.CONFIRMATION);
+        alert.setTitle("기록 초기화");
+        alert.setHeaderText(null);
+        alert.setContentText("정말 모든 기록을 초기화하시겠습니까?");
+
+        alert.showAndWait().ifPresent(result -> {
+            if (result == ButtonType.OK) {
+                resetScoreSettings();
+            }
+        });
+    }
+
+    private void resetSettings() {
+        // 색맹 모드 초기화
+        isColorBlindModeOn = false;
+        colorBlindModeToggle.setSelected(false);
+        colorBlindModeToggle.setText("off");
+
+        // 화면 크기 초기화
+        resizeMenuButton.setText("1");
+
+        // 다른 설정들도 초기화하는 코드 추가
+        System.out.println("기본 설정으로 되돌림");
+    }
+
+    private void resetScoreSettings() {
+        // 기록 초기화 코드 입력 공간
+    }
+}

--- a/src/TetrisWindow.java
+++ b/src/TetrisWindow.java
@@ -1,0 +1,93 @@
+import javafx.application.Application;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+import javafx.scene.input.KeyCode;
+
+public class TetrisWindow extends Application {
+
+    @Override
+    public void start(Stage primaryStage) {
+        primaryStage.setTitle("TetriS");
+
+        BorderPane root = new BorderPane();
+
+        // 로고 생성
+        Text logoText = new Text("TetriS");
+        logoText.setFont(Font.font("Arial", FontWeight.BOLD, 24));
+        logoText.setFill(Color.BLACK);
+        VBox logoPane = new VBox(logoText);
+        logoPane.setPadding(new Insets(10));
+        logoPane.setStyle("-fx-background-color: #800080;");
+
+        // 버튼 생성
+        VBox buttonPane = new VBox(10);
+        buttonPane.setAlignment(Pos.CENTER);
+        Button gameStartButton = new Button("게임시작");
+        Button scoreBoardButton = new Button("스코어보드");
+        Button settingsButton = new Button("설정");
+        Button exitButton = new Button("게임종료");
+        buttonPane.getChildren().addAll(gameStartButton, scoreBoardButton, settingsButton, exitButton);
+
+        // 설정 창 생성
+        SettingsWindow settingsWindow = new SettingsWindow(primaryStage);
+        settingsButton.setOnAction(event -> settingsWindow.show());
+
+        // 게임 종료 버튼 동작 설정
+        exitButton.setOnAction(event -> primaryStage.close());
+
+        // 버튼에 대한 포커스 설정
+        gameStartButton.setFocusTraversable(true);
+        scoreBoardButton.setFocusTraversable(true);
+        settingsButton.setFocusTraversable(true);
+        exitButton.setFocusTraversable(true);
+
+        // 엔터 키로 버튼 선택하기
+        gameStartButton.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                // 버튼에 대한 동작 수행
+                gameStartButton.fire();
+            }
+        });
+
+        scoreBoardButton.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                // 버튼에 대한 동작 수행
+                scoreBoardButton.fire();
+            }
+        });
+
+        settingsButton.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                // 버튼에 대한 동작 수행
+                settingsButton.fire();
+            }
+        });
+
+        exitButton.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                // 버튼에 대한 동작 수행
+                exitButton.fire();
+            }
+        });
+
+        root.setTop(logoPane);
+        root.setCenter(buttonPane);
+
+        Scene scene = new Scene(root, 300, 400);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}


### PR DESCRIPTION
색맹모드 - 토글버튼 (on/off) 기본값은 off
나중에 색 설정시 연동해서 바뀌도록 설정
화면 크기 조절 - 1, 2, 3 지정가능
추후에 크기 설정 시 1, 2, 3 값 대체
키 설정 - 아직 미구현
=> 윈도우 하나 새로 띄워서 게임 키 설정 되어있는 부분 건드리도록 설계해야할 듯?
기록초기화 - 아직 미구현
스코어보드 구현 시 연동
=> 알림창 정도만 뜨도록 설정
기본 설정으로 되돌리기 - 버튼 입력 시 설정창 내용 기본값으로 돌아가도록 설정
=>알림창 등장
뒤로가기 - 뒤로가기
[!] 메인 화면처럼 키보드 입력 받게 하고 싶지만 자잘한 오류가 많이 나서 일단 보류중. 그렇다고 설정창은 마우스 입력만 받게 만들면 좀 짜치니까 빠른 시일내에 답을 찾아보겠음
[!] 메인 화면에서 설정창 누를 시 설정창이랑 메인화면이 동시에 등장하는데 설정창만 띄우고 뒤로가기 누를 시 메인화면만 등장(한 번에 하나의 창만 띄우기)하게 하고 싶은데 이것도 좀 오류가 많이남(swing에서는 잘됐는데………) 이부분도 확인 후 추후 수정가능할 시 수정하겠음
512e8e7
